### PR TITLE
Allow common CJK punctuation in name tags

### DIFF
--- a/src/economy-constants.ts
+++ b/src/economy-constants.ts
@@ -41,7 +41,7 @@ export const CS2_STICKER_OFFSET_FACTOR = 0.0001;
 export const CS2_STICKER_ROTATION_STEP = 0.5;
 export const CS2_WEAR_FACTOR = 0.000001;
 
-export const CS2_NAMETAG_RE: RegExp = /^[A-Za-z0-9`!@#$%^&*-+=(){}\[\]\/\|\\,.?:;'_\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\s]{0,20}$/u;
+export const CS2_NAMETAG_RE: RegExp = /^[A-Za-z0-9`!@#$%^&*-+=(){}\[\]\/\|\\,.?:;'_，。；！\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\s]{0,20}$/u;
 
 export const CS2_CONTRACT_TOOL_DEF = 62;
 export const CS2_NAMETAG_TOOL_DEF = 1200;

--- a/src/economy.test.ts
+++ b/src/economy.test.ts
@@ -88,6 +88,8 @@ test("nametag validation", () => {
     expect(CS2Economy.safeValidateNameTag(" fail")).toBeFalsy();
     expect(CS2Economy.safeValidateNameTag("小島 秀夫")).toBeTruthy();
     expect(CS2Economy.safeValidateNameTag("孔子")).toBeTruthy();
+    expect(CS2Economy.safeValidateNameTag("千古风流今在此，万里功名莫放休")).toBeTruthy();
+    expect(CS2Economy.safeValidateNameTag("中文，句号。分号；感叹！")).toBeTruthy();
     expect(CS2Economy.safeValidateNameTag("bo$$u")).toBeTruthy();
     expect(CS2Economy.safeValidateNameTag("toolongnametagtoolongnametag")).toBeFalsy();
 });


### PR DESCRIPTION
## Summary

- Allow the common CJK punctuation characters `，。；！` in CS2 name tags.
- Add regression coverage for a real-world Chinese name tag and for all four characters.

## Why

`CS2_NAMETAG_RE` already accepts Han characters, but rejects common full-width punctuation used with them. One real-world example is kyousuke's name tag:

`千古风流今在此，万里功名莫放休`

The text is within the existing 20-character limit, but the full-width comma currently makes the whole name tag fail validation. This change only extends the accepted character set; the existing length and leading-space rules remain unchanged.

## Testing

- `npm test -- src/economy.test.ts`
- `npm run typecheck`
- `npm run test`
- `npm run prepack`
